### PR TITLE
Proposed changes

### DIFF
--- a/apps/language_server/lib/language_server/protocol/text_edit.ex
+++ b/apps/language_server/lib/language_server/protocol/text_edit.ex
@@ -1,0 +1,9 @@
+defmodule ElixirLS.LanguageServer.Protocol.TextEdit do
+  @moduledoc """
+  Corresponds to the LSP interface of the same name.
+
+  For details see https://microsoft.github.io/language-server-protocol/specification#textEdit
+  """
+  @derive JasonVendored.Encoder
+  defstruct [:range, :newText]
+end

--- a/apps/language_server/test/support/test_utils.ex
+++ b/apps/language_server/test/support/test_utils.ex
@@ -1,0 +1,10 @@
+defmodule ElixirLS.LanguageServer.Test.TestUtils do
+  alias ElixirLS.LanguageServer.Protocol.TextEdit
+  alias ElixirLS.LanguageServer.SourceFile
+
+  def apply_text_edit(text, %TextEdit{} = text_edit) do
+    %TextEdit{range: range, newText: new_text} = text_edit
+
+    SourceFile.apply_edit(text, range, new_text)
+  end
+end


### PR DESCRIPTION
Make `to_pipe_at_cursor/3` public to facilitate testing. I think we
should still keep some integration-level testing, but I think the
majority of the test cases can be simplified. I didn't implement making
`from_pipe_at_cursor/3` public, but I think it would make sense as well.

Introduce `ElixirLS.LanguageServer.Protocol.TextEdit` and return it from
`to_pipe_at_cursor/3` and `from_pipe_at_cursor/3`

Add an example of a working simpler test, and add a few examples of
broken tests (as mentioned in https://github.com/elixir-lsp/elixir-ls/pull/521#pullrequestreview-664723438)