### PR TITLE
Handle more cases for manipulating pipes

### DIFF
--- a/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes.ex
+++ b/apps/language_server/lib/language_server/providers/execute_command/manipulate_pipes.ex
@@ -85,8 +85,7 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes do
               {remaining_text,
                %{
                  acc
-                 | walked_text: acc.walked_text <> current_char,
-                   function_call: nil
+                 | walked_text: acc.walked_text <> current_char
                }}
             end
           else
@@ -390,17 +389,17 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipes do
     starts_before =
       cond do
         start_line < line -> true
-        start_line == line && start_character <= char -> true
+        start_line == line and start_character <= char -> true
         true -> false
       end
 
     ends_after =
       cond do
         end_line > line -> true
-        end_line == line && end_character >= char -> true
+        end_line == line and end_character >= char -> true
         true -> false
       end
 
-    starts_before && ends_after
+    starts_before and ends_after
   end
 end

--- a/apps/language_server/test/providers/execute_command/manipulate_pipes_test.exs
+++ b/apps/language_server/test/providers/execute_command/manipulate_pipes_test.exs
@@ -1268,8 +1268,6 @@ defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand.ManipulatePipesTest d
   def line_char(text, line, char) do
       String.split(text, "\n")
       |> Enum.at(line)
-      |> IO.inspect(label: "line")
-      |> String.slice(char, 10)
-      |> IO.inspect(label: "rest of line")
+      |> String.slice(char, ?\n)
   end
 end


### PR DESCRIPTION
Changed the function call detection to not "jump forward", as part of
this if the user requests an index that is not on a function call, then
no action is performed.

Also fix handling of piping function calls that span multiple lines by
adjusting the returned line and column to point to the correct start
location by counting backward.